### PR TITLE
support multiple or no logger

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -2,12 +2,12 @@ package grimoire
 
 // Adapter interface
 type Adapter interface {
-	Count(Query, Logger) (int, error)
-	All(Query, interface{}, Logger) (int, error)
-	Delete(Query, Logger) error
-	Insert(Query, map[string]interface{}, Logger) (interface{}, error)
-	InsertAll(Query, []string, []map[string]interface{}, Logger) ([]interface{}, error)
-	Update(Query, map[string]interface{}, Logger) error
+	Count(Query, ...Logger) (int, error)
+	All(Query, interface{}, ...Logger) (int, error)
+	Delete(Query, ...Logger) error
+	Insert(Query, map[string]interface{}, ...Logger) (interface{}, error)
+	InsertAll(Query, []string, []map[string]interface{}, ...Logger) ([]interface{}, error)
+	Update(Query, map[string]interface{}, ...Logger) error
 
 	Begin() (Adapter, error)
 	Commit() error

--- a/adapter/mysql/mysql_test.go
+++ b/adapter/mysql/mysql_test.go
@@ -3,7 +3,6 @@ package mysql
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/Fs02/go-paranoid"
 	"github.com/Fs02/grimoire"
@@ -13,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func logger(string, time.Duration, error) {}
-
 func init() {
 	adapter, err := Open(dsn())
 	if err != nil {
@@ -22,9 +19,9 @@ func init() {
 	}
 	defer adapter.Close()
 
-	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS addresses;`, []interface{}{}, logger)
+	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS addresses;`, nil)
 	paranoid.Panic(err)
-	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS users;`, []interface{}{}, logger)
+	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS users;`, nil)
 	paranoid.Panic(err)
 
 	_, _, err = adapter.Exec(`CREATE TABLE users (
@@ -35,7 +32,7 @@ func init() {
 		note varchar(50),
 		created_at DATETIME,
 		updated_at DATETIME
-	);`, []interface{}{}, logger)
+	);`, nil)
 	paranoid.Panic(err)
 
 	_, _, err = adapter.Exec(`CREATE TABLE addresses (
@@ -45,7 +42,7 @@ func init() {
 		created_at DATETIME,
 		updated_at DATETIME,
 		FOREIGN KEY (user_id) REFERENCES users(id)
-	);`, []interface{}{}, logger)
+	);`, nil)
 	paranoid.Panic(err)
 }
 
@@ -108,7 +105,7 @@ func TestAdapterInsertAllError(t *testing.T) {
 		{"notexist": "13"},
 	}
 
-	_, err = adapter.InsertAll(grimoire.Repo{}.From("users"), fields, allchanges, logger)
+	_, err = adapter.InsertAll(grimoire.Repo{}.From("users"), fields, allchanges)
 
 	assert.NotNil(t, err)
 }
@@ -142,7 +139,7 @@ func TestAdapterQueryError(t *testing.T) {
 
 	out := struct{}{}
 
-	_, err = adapter.Query(&out, "error", []interface{}{}, logger)
+	_, err = adapter.Query(&out, "error", nil)
 	assert.NotNil(t, err)
 }
 
@@ -153,7 +150,7 @@ func TestAdapterExecError(t *testing.T) {
 	}
 	defer adapter.Close()
 
-	_, _, err = adapter.Exec("error", []interface{}{}, logger)
+	_, _, err = adapter.Exec("error", nil)
 	assert.NotNil(t, err)
 }
 

--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -27,7 +27,7 @@ func Open(dsn string) (*Adapter, error) {
 }
 
 // Insert inserts a record to database and returns its id.
-func (adapter *Adapter) Insert(query grimoire.Query, changes map[string]interface{}, logger grimoire.Logger) (interface{}, error) {
+func (adapter *Adapter) Insert(query grimoire.Query, changes map[string]interface{}, loggers ...grimoire.Logger) (interface{}, error) {
 	statement, args := sql.NewBuilder(adapter.Placeholder, adapter.Ordinal).
 		Returning("id").
 		Insert(query.Collection, changes)
@@ -36,19 +36,19 @@ func (adapter *Adapter) Insert(query grimoire.Query, changes map[string]interfac
 		ID int64
 	}
 
-	_, err := adapter.Query(&result, statement, args, logger)
+	_, err := adapter.Query(&result, statement, args, loggers...)
 	return result.ID, err
 }
 
 // InsertAll inserts all record to database and returns its ids.
-func (adapter *Adapter) InsertAll(query grimoire.Query, fields []string, allchanges []map[string]interface{}, logger grimoire.Logger) ([]interface{}, error) {
+func (adapter *Adapter) InsertAll(query grimoire.Query, fields []string, allchanges []map[string]interface{}, loggers ...grimoire.Logger) ([]interface{}, error) {
 	statement, args := sql.NewBuilder(adapter.Placeholder, adapter.Ordinal).Returning("id").InsertAll(query.Collection, fields, allchanges)
 
 	var result []struct {
 		ID int64
 	}
 
-	_, err := adapter.Query(&result, statement, args, logger)
+	_, err := adapter.Query(&result, statement, args, loggers...)
 
 	ids := make([]interface{}, 0, len(result))
 	for _, r := range result {

--- a/adapter/postgres/postgres_test.go
+++ b/adapter/postgres/postgres_test.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/Fs02/go-paranoid"
 	"github.com/Fs02/grimoire"
@@ -13,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func logger(string, time.Duration, error) {}
-
 func init() {
 	adapter, err := Open(dsn())
 	if err != nil {
@@ -22,9 +19,9 @@ func init() {
 	}
 	defer adapter.Close()
 
-	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS addresses;`, []interface{}{}, logger)
+	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS addresses;`, nil)
 	paranoid.Panic(err)
-	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS users;`, []interface{}{}, logger)
+	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS users;`, nil)
 	paranoid.Panic(err)
 
 	_, _, err = adapter.Exec(`CREATE TABLE users (
@@ -35,7 +32,7 @@ func init() {
 		note varchar(50),
 		created_at TIMESTAMP,
 		updated_at TIMESTAMP
-	);`, []interface{}{}, logger)
+	);`, nil)
 	paranoid.Panic(err)
 
 	_, _, err = adapter.Exec(`CREATE TABLE addresses (
@@ -44,7 +41,7 @@ func init() {
 		address VARCHAR(60) NOT NULL DEFAULT '',
 		created_at TIMESTAMP,
 		updated_at TIMESTAMP
-	);`, []interface{}{}, logger)
+	);`, nil)
 	paranoid.Panic(err)
 }
 
@@ -107,7 +104,7 @@ func TestAdapterInsertAllError(t *testing.T) {
 		{"notexist": "13"},
 	}
 
-	_, err = adapter.InsertAll(grimoire.Repo{}.From("users"), fields, allchanges, logger)
+	_, err = adapter.InsertAll(grimoire.Repo{}.From("users"), fields, allchanges)
 
 	assert.NotNil(t, err)
 }
@@ -141,7 +138,7 @@ func TestAdapterQueryError(t *testing.T) {
 
 	out := struct{}{}
 
-	_, err = adapter.Query(&out, "error", []interface{}{}, logger)
+	_, err = adapter.Query(&out, "error", nil)
 	assert.NotNil(t, err)
 }
 
@@ -152,7 +149,7 @@ func TestAdapterExecError(t *testing.T) {
 	}
 	defer adapter.Close()
 
-	_, _, err = adapter.Exec("error", []interface{}{}, logger)
+	_, _, err = adapter.Exec("error", nil)
 	assert.NotNil(t, err)
 }
 

--- a/adapter/sql/sql_test.go
+++ b/adapter/sql/sql_test.go
@@ -3,7 +3,6 @@ package sql
 import (
 	db "database/sql"
 	"testing"
-	"time"
 
 	paranoid "github.com/Fs02/go-paranoid"
 	"github.com/Fs02/grimoire"
@@ -12,8 +11,6 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 )
-
-func logger(string, time.Duration, error) {}
 
 func open() (*Adapter, error) {
 	var err error
@@ -30,7 +27,7 @@ func open() (*Adapter, error) {
 	_, _, execerr := adapter.Exec(`CREATE TABLE test (
 		id INTEGER PRIMARY KEY,
 		name STRING
-	);`, []interface{}{}, logger)
+	);`, nil)
 	paranoid.Panic(execerr)
 
 	return adapter, err
@@ -149,7 +146,7 @@ func TestAdapterInsertAllError(t *testing.T) {
 		{"notexist": "13"},
 	}
 
-	_, err = adapter.InsertAll(grimoire.Repo{}.From("test"), fields, allchanges, logger)
+	_, err = adapter.InsertAll(grimoire.Repo{}.From("test"), fields, allchanges)
 
 	assert.NotNil(t, err)
 }
@@ -183,7 +180,7 @@ func TestAdapterQueryError(t *testing.T) {
 
 	out := struct{}{}
 
-	_, err = adapter.Query(&out, "error", []interface{}{}, logger)
+	_, err = adapter.Query(&out, "error", nil)
 	assert.NotNil(t, err)
 }
 
@@ -194,6 +191,6 @@ func TestAdapterExecError(t *testing.T) {
 	}
 	defer adapter.Close()
 
-	_, _, err = adapter.Exec("error", []interface{}{}, logger)
+	_, _, err = adapter.Exec("error", nil)
 	assert.NotNil(t, err)
 }

--- a/adapter/sqlite3/sqlite3_test.go
+++ b/adapter/sqlite3/sqlite3_test.go
@@ -3,7 +3,6 @@ package sqlite3
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/Fs02/go-paranoid"
 	"github.com/Fs02/grimoire"
@@ -13,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func logger(string, time.Duration, error) {}
-
 func init() {
 	adapter, err := Open(dsn())
 	if err != nil {
@@ -22,9 +19,9 @@ func init() {
 	}
 	defer adapter.Close()
 
-	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS addresses;`, []interface{}{}, logger)
+	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS addresses;`, nil)
 	paranoid.Panic(err)
-	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS users;`, []interface{}{}, logger)
+	_, _, err = adapter.Exec(`DROP TABLE IF EXISTS users;`, nil)
 	paranoid.Panic(err)
 
 	_, _, err = adapter.Exec(`CREATE TABLE users (
@@ -35,7 +32,7 @@ func init() {
 		note varchar(50),
 		created_at DATETIME,
 		updated_at DATETIME
-	);`, []interface{}{}, logger)
+	);`, nil)
 	paranoid.Panic(err)
 
 	_, _, err = adapter.Exec(`CREATE TABLE addresses (
@@ -45,7 +42,7 @@ func init() {
 		created_at DATETIME,
 		updated_at DATETIME,
 		FOREIGN KEY (user_id) REFERENCES users(id)
-	);`, []interface{}{}, logger)
+	);`, nil)
 	paranoid.Panic(err)
 }
 
@@ -108,7 +105,7 @@ func TestAdapterInsertAllError(t *testing.T) {
 		{"notexist": "13"},
 	}
 
-	_, err = adapter.InsertAll(grimoire.Repo{}.From("users"), fields, allchanges, logger)
+	_, err = adapter.InsertAll(grimoire.Repo{}.From("users"), fields, allchanges)
 
 	assert.NotNil(t, err)
 }
@@ -142,7 +139,7 @@ func TestAdapterQueryError(t *testing.T) {
 
 	out := struct{}{}
 
-	_, err = adapter.Query(&out, "error", []interface{}{}, logger)
+	_, err = adapter.Query(&out, "error", nil)
 	assert.NotNil(t, err)
 }
 
@@ -153,7 +150,7 @@ func TestAdapterExecError(t *testing.T) {
 	}
 	defer adapter.Close()
 
-	_, _, err = adapter.Exec("error", []interface{}{}, logger)
+	_, _, err = adapter.Exec("error", nil)
 	assert.NotNil(t, err)
 }
 

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -20,32 +20,32 @@ func (adapter TestAdapter) Close() error {
 	return args.Error(0)
 }
 
-func (adapter TestAdapter) Count(query Query, logger Logger) (int, error) {
+func (adapter TestAdapter) Count(query Query, logger ...Logger) (int, error) {
 	args := adapter.Called(query)
 	return args.Int(0), args.Error(1)
 }
 
-func (adapter TestAdapter) All(query Query, doc interface{}, logger Logger) (int, error) {
+func (adapter TestAdapter) All(query Query, doc interface{}, logger ...Logger) (int, error) {
 	args := adapter.Called(query, doc)
 	return args.Int(0), args.Error(1)
 }
 
-func (adapter TestAdapter) Insert(query Query, ch map[string]interface{}, logger Logger) (interface{}, error) {
+func (adapter TestAdapter) Insert(query Query, ch map[string]interface{}, logger ...Logger) (interface{}, error) {
 	args := adapter.Called(query, ch)
 	return args.Get(0), args.Error(1)
 }
 
-func (adapter TestAdapter) InsertAll(query Query, fields []string, chs []map[string]interface{}, logger Logger) ([]interface{}, error) {
+func (adapter TestAdapter) InsertAll(query Query, fields []string, chs []map[string]interface{}, logger ...Logger) ([]interface{}, error) {
 	args := adapter.Called(query, chs)
 	return args.Get(0).([]interface{}), args.Error(1)
 }
 
-func (adapter TestAdapter) Update(query Query, ch map[string]interface{}, logger Logger) error {
+func (adapter TestAdapter) Update(query Query, ch map[string]interface{}, logger ...Logger) error {
 	args := adapter.Called(query, ch)
 	return args.Error(0)
 }
 
-func (adapter TestAdapter) Delete(query Query, logger Logger) error {
+func (adapter TestAdapter) Delete(query Query, logger ...Logger) error {
 	args := adapter.Called(query)
 	return args.Error(0)
 }

--- a/logger.go
+++ b/logger.go
@@ -8,11 +8,19 @@ import (
 // Logger defines function signature for custom logger.
 type Logger func(string, time.Duration, error)
 
-// logger is default logger used to log query. It's exported for adapter testing purpose.
-func logger(query string, duration time.Duration, err error) {
+// DefaultLogger log query suing standard log library.
+func DefaultLogger(query string, duration time.Duration, err error) {
 	if err != nil {
 		log.Print("[", duration, "] ", err, " - ", query)
 	} else {
 		log.Print("[", duration, "] OK - ", query)
+	}
+}
+
+// Log using multiple logger.
+// This function intended to be used within adapter.
+func Log(logger []Logger, statement string, duration time.Duration, err error) {
+	for _, l := range logger {
+		l(statement, duration, err)
 	}
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -8,9 +8,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDefaultLogger(t *testing.T) {
+	assert.NotPanics(t, func() {
+		DefaultLogger("", time.Second, nil)
+		DefaultLogger("", time.Second, errors.UnexpectedError("error"))
+	})
+}
+
 func TestLogger(t *testing.T) {
 	assert.NotPanics(t, func() {
-		logger("", time.Second, nil)
-		logger("", time.Second, errors.UnexpectedError("error"))
+		Log([]Logger{DefaultLogger}, "", time.Second, nil)
 	})
 }

--- a/query.go
+++ b/query.go
@@ -135,7 +135,7 @@ func (query Query) Set(field string, value interface{}) Query {
 // If no result found, it'll return not found error.
 func (query Query) One(record interface{}) error {
 	query.LimitResult = 1
-	count, err := query.repo.adapter.All(query, record, query.repo.logger)
+	count, err := query.repo.adapter.All(query, record, query.repo.logger...)
 
 	if err != nil {
 		return errors.Wrap(err)
@@ -154,7 +154,7 @@ func (query Query) MustOne(record interface{}) {
 
 // All retrieves all results that match the query.
 func (query Query) All(record interface{}) error {
-	_, err := query.repo.adapter.All(query, record, query.repo.logger)
+	_, err := query.repo.adapter.All(query, record, query.repo.logger...)
 	return err
 }
 
@@ -166,7 +166,7 @@ func (query Query) MustAll(record interface{}) {
 
 // Count retrieves count of results that match the query.
 func (query Query) Count() (int, error) {
-	count, err := query.repo.adapter.Count(query, query.repo.logger)
+	count, err := query.repo.adapter.Count(query, query.repo.logger...)
 	return count, err
 }
 
@@ -193,7 +193,7 @@ func (query Query) Insert(record interface{}, chs ...*changeset.Changeset) error
 		cloneQuery(changes, query.Changes)
 
 		var id interface{}
-		id, err = query.repo.adapter.Insert(query, changes, query.repo.logger)
+		id, err = query.repo.adapter.Insert(query, changes, query.repo.logger...)
 		ids = append(ids, id)
 	} else if len(chs) > 1 {
 		// multiple insert
@@ -210,11 +210,11 @@ func (query Query) Insert(record interface{}, chs ...*changeset.Changeset) error
 			allchanges[i] = changes
 		}
 
-		ids, err = query.repo.adapter.InsertAll(query, fields, allchanges, query.repo.logger)
+		ids, err = query.repo.adapter.InsertAll(query, fields, allchanges, query.repo.logger...)
 	} else if len(query.Changes) > 0 {
 		// set only
 		var id interface{}
-		id, err = query.repo.adapter.Insert(query, query.Changes, query.repo.logger)
+		id, err = query.repo.adapter.Insert(query, query.Changes, query.repo.logger...)
 		ids = append(ids, id)
 	}
 
@@ -254,7 +254,7 @@ func (query Query) Update(record interface{}, chs ...*changeset.Changeset) error
 	}
 
 	// perform update
-	err := query.repo.adapter.Update(query, changes, query.repo.logger)
+	err := query.repo.adapter.Update(query, changes, query.repo.logger...)
 	if err != nil {
 		return errors.Wrap(err)
 	}
@@ -330,7 +330,7 @@ func (query Query) MustSave(record interface{}) {
 
 // Delete deletes all results that match the query.
 func (query Query) Delete() error {
-	return errors.Wrap(query.repo.adapter.Delete(query, query.repo.logger))
+	return errors.Wrap(query.repo.adapter.Delete(query, query.repo.logger...))
 }
 
 // MustDelete deletes all results that match the query.

--- a/repo.go
+++ b/repo.go
@@ -7,19 +7,19 @@ import (
 // Repo defines grimoire repository.
 type Repo struct {
 	adapter Adapter
-	logger  Logger
+	logger  []Logger
 }
 
 // New create new repo using adapter.
 func New(adapter Adapter) Repo {
 	return Repo{
 		adapter: adapter,
-		logger:  logger,
+		logger:  []Logger{DefaultLogger},
 	}
 }
 
 // SetLogger replace default logger with custom logger.
-func (repo *Repo) SetLogger(logger Logger) {
+func (repo *Repo) SetLogger(logger ...Logger) {
 	repo.logger = logger
 }
 

--- a/repo_test.go
+++ b/repo_test.go
@@ -16,7 +16,7 @@ func TestNew(t *testing.T) {
 func TestRepoSetLogger(t *testing.T) {
 	repo := Repo{}
 	assert.Nil(t, repo.logger)
-	repo.SetLogger(logger)
+	repo.SetLogger(DefaultLogger)
 	assert.NotNil(t, repo.logger)
 }
 


### PR DESCRIPTION
this allows to compose multiple logger (ie: json logger and prometheus metrics) and provide an easier way to use adapter directly.