### PR TITLE
handle cast on zero value

### DIFF
--- a/changeset/cast.go
+++ b/changeset/cast.go
@@ -33,15 +33,15 @@ func Cast(data interface{}, params params.Params, fields []string, opts ...Optio
 
 	for _, field := range fields {
 		typ, texist := ch.types[field]
-		currentValue, vexist := ch.values[field]
+		value, vexist := ch.values[field]
 
 		if !params.Exists(field) || !texist {
 			continue
 		}
 
-		if value, valid := params.GetWithType(field, typ); valid {
-			if (typ.Kind() == reflect.Slice || typ.Kind() == reflect.Array) || (!vexist && value != nil) || (vexist && currentValue != value) {
-				ch.changes[field] = value
+		if change, valid := params.GetWithType(field, typ); valid {
+			if (typ.Kind() == reflect.Slice || typ.Kind() == reflect.Array) || (!vexist && change != nil) || (vexist && value != change) || (change == reflect.Zero(typ).Interface()) {
+				ch.changes[field] = change
 			}
 		} else {
 			msg := strings.Replace(options.message, "{field}", field, 1)

--- a/changeset/cast_test.go
+++ b/changeset/cast_test.go
@@ -159,17 +159,22 @@ func TestCast_existingChangeset(t *testing.T) {
 }
 
 func TestCast_unchanged(t *testing.T) {
-	var data struct {
+	data := struct {
 		Field1 int `db:"field1"`
 		Field2 string
 		Field3 bool
 		Field4 *bool
+	}{
+		Field1: 1,
+		Field2: "2",
+		Field3: true,
+		Field4: nil,
 	}
 
 	input := params.Map{
-		"field1": 0,
-		"field2": "",
-		"field3": false,
+		"field1": 1,
+		"field2": "2",
+		"field3": true,
 		"field4": nil,
 	}
 
@@ -183,9 +188,9 @@ func TestCast_unchanged(t *testing.T) {
 	}
 
 	expectedValues := map[string]interface{}{
-		"field1": 0,
-		"field2": "",
-		"field3": false,
+		"field1": 1,
+		"field2": "2",
+		"field3": true,
 	}
 
 	ch := Cast(data, input, []string{"field1", "field2", "field3", "field4"})
@@ -408,6 +413,85 @@ func TestCast_basicWithValue(t *testing.T) {
 	assert.Nil(t, ch.Errors())
 	assert.Equal(t, expectedChanges, ch.Changes())
 	assert.Equal(t, expectedValues, ch.values)
+	assert.Equal(t, expectedTypes, ch.types)
+}
+
+func TestCast_basicZeroValue(t *testing.T) {
+	data := struct {
+		Field1  bool
+		Field2  int
+		Field3  int8
+		Field4  int16
+		Field5  int32
+		Field6  int64
+		Field7  uint
+		Field8  uint8
+		Field9  uint16
+		Field10 uint32
+		Field11 uint64
+		Field12 uintptr
+		Field13 float32
+		Field14 float64
+		Field15 string
+	}{}
+
+	var input = params.Map{
+		"field1":  false,
+		"field2":  0,
+		"field3":  0,
+		"field4":  0,
+		"field5":  0,
+		"field6":  0,
+		"field7":  0,
+		"field8":  0,
+		"field9":  0,
+		"field10": 0,
+		"field11": 0,
+		"field12": 0,
+		"field13": 0,
+		"field14": 0,
+		"field15": "",
+	}
+
+	expectedValuesAndChanges := map[string]interface{}{
+		"field1":  false,
+		"field2":  0,
+		"field3":  int8(0),
+		"field4":  int16(0),
+		"field5":  int32(0),
+		"field6":  int64(0),
+		"field7":  uint(0),
+		"field8":  uint8(0),
+		"field9":  uint16(0),
+		"field10": uint32(0),
+		"field11": uint64(0),
+		"field12": uintptr(0),
+		"field13": float32(0),
+		"field14": float64(0),
+		"field15": "",
+	}
+
+	ch := Cast(data, input, []string{
+		"field1",
+		"field2",
+		"field3",
+		"field4",
+		"field5",
+		"field6",
+		"field7",
+		"field8",
+		"field9",
+		"field10",
+		"field11",
+		"field12",
+		"field13",
+		"field14",
+		"field15",
+	})
+
+	assert.Nil(t, ch.Errors())
+	assert.Equal(t, expectedValuesAndChanges, ch.Changes())
+	assert.Equal(t, expectedValuesAndChanges, ch.values)
 	assert.Equal(t, expectedTypes, ch.types)
 }
 


### PR DESCRIPTION
previously zero value will always be ignored if current struct is empty(zero), there for other validations such as max/min will be skipped because of this.
to solve this problem, every zero value will always be treated as changes even if it's not different than the current value.