### PR TITLE
Preload Target Type Not Changed If It is Pointer

### DIFF
--- a/changeset/cast_test.go
+++ b/changeset/cast_test.go
@@ -159,17 +159,22 @@ func TestCast_existingChangeset(t *testing.T) {
 }
 
 func TestCast_unchanged(t *testing.T) {
-	var data struct {
+	data := struct {
 		Field1 int `db:"field1"`
 		Field2 string
 		Field3 bool
 		Field4 *bool
+	}{
+		Field1: 1,
+		Field2: "1",
+		Field3: true,
+		Field4: nil,
 	}
 
 	input := params.Map{
-		"field1": 0,
-		"field2": "",
-		"field3": false,
+		"field1": 1,
+		"field2": "1",
+		"field3": true,
 		"field4": nil,
 	}
 
@@ -183,9 +188,9 @@ func TestCast_unchanged(t *testing.T) {
 	}
 
 	expectedValues := map[string]interface{}{
-		"field1": 0,
-		"field2": "",
-		"field3": false,
+		"field1": 1,
+		"field2": "1",
+		"field3": true,
 	}
 
 	ch := Cast(data, input, []string{"field1", "field2", "field3", "field4"})
@@ -385,6 +390,103 @@ func TestCast_basicWithValue(t *testing.T) {
 		"field13": float32(1),
 		"field14": float64(1),
 		"field15": "1",
+	}
+
+	ch := Cast(data, input, []string{
+		"field1",
+		"field2",
+		"field3",
+		"field4",
+		"field5",
+		"field6",
+		"field7",
+		"field8",
+		"field9",
+		"field10",
+		"field11",
+		"field12",
+		"field13",
+		"field14",
+		"field15",
+	})
+
+	assert.Nil(t, ch.Errors())
+	assert.Equal(t, expectedChanges, ch.Changes())
+	assert.Equal(t, expectedValues, ch.values)
+	assert.Equal(t, expectedTypes, ch.types)
+}
+
+func TestCast_basicZeroValue(t *testing.T) {
+	data := struct {
+		Field1  bool
+		Field2  int
+		Field3  int8
+		Field4  int16
+		Field5  int32
+		Field6  int64
+		Field7  uint
+		Field8  uint8
+		Field9  uint16
+		Field10 uint32
+		Field11 uint64
+		Field12 uintptr
+		Field13 float32
+		Field14 float64
+		Field15 string
+	}{}
+
+	var input = params.Map{
+		"field1":  false,
+		"field2":  0,
+		"field3":  0,
+		"field4":  0,
+		"field5":  0,
+		"field6":  0,
+		"field7":  0,
+		"field8":  0,
+		"field9":  0,
+		"field10": 0,
+		"field11": 0,
+		"field12": 0,
+		"field13": 0,
+		"field14": 0,
+		"field15": "",
+	}
+
+	expectedValues := map[string]interface{}{
+		"field1":  false,
+		"field2":  0,
+		"field3":  int8(0),
+		"field4":  int16(0),
+		"field5":  int32(0),
+		"field6":  int64(0),
+		"field7":  uint(0),
+		"field8":  uint8(0),
+		"field9":  uint16(0),
+		"field10": uint32(0),
+		"field11": uint64(0),
+		"field12": uintptr(0),
+		"field13": float32(0),
+		"field14": float64(0),
+		"field15": "",
+	}
+
+	// Empty string is ignored because it's default of empty values
+	expectedChanges := map[string]interface{}{
+		"field1":  false,
+		"field2":  0,
+		"field3":  int8(0),
+		"field4":  int16(0),
+		"field5":  int32(0),
+		"field6":  int64(0),
+		"field7":  uint(0),
+		"field8":  uint8(0),
+		"field9":  uint16(0),
+		"field10": uint32(0),
+		"field11": uint64(0),
+		"field12": uintptr(0),
+		"field13": float32(0),
+		"field14": float64(0),
 	}
 
 	ch := Cast(data, input, []string{

--- a/changeset/change.go
+++ b/changeset/change.go
@@ -4,7 +4,7 @@ package changeset
 func Change(schema interface{}) *Changeset {
 	ch := &Changeset{}
 	ch.changes = make(map[string]interface{})
-	ch.values, ch.types = mapSchema(schema)
+	ch.values, ch.types, _ = mapSchema(schema)
 
 	return ch
 }

--- a/changeset/convert.go
+++ b/changeset/convert.go
@@ -4,7 +4,7 @@ package changeset
 func Convert(data interface{}) *Changeset {
 	ch := &Changeset{}
 	ch.values = make(map[string]interface{})
-	ch.changes, ch.types = mapSchema(data)
+	ch.changes, ch.types, _ = mapSchema(data)
 
 	return ch
 }

--- a/changeset/options.go
+++ b/changeset/options.go
@@ -9,6 +9,7 @@ type Options struct {
 	changeOnly  bool
 	required    bool
 	sourceField string
+	emptyValues []interface{}
 }
 
 // Option for changeset operation.
@@ -55,15 +56,24 @@ func ChangeOnly(changeOnly bool) Option {
 	}
 }
 
+// Required is used to define whether an assoc needs to be required or not.
 func Required(required bool) Option {
 	return func(opts *Options) {
 		opts.required = required
 	}
 }
 
-// Source to define used field name in params.
+// SourceField to define used field name in params.
 func SourceField(field string) Option {
 	return func(opts *Options) {
 		opts.sourceField = field
+	}
+}
+
+// EmptyValues defines list of empty values when casting.
+// default to [""]
+func EmptyValues(values ...interface{}) Option {
+	return func(opts *Options) {
+		opts.emptyValues = values
 	}
 }

--- a/changeset/options_test.go
+++ b/changeset/options_test.go
@@ -16,6 +16,7 @@ func TestOptions(t *testing.T) {
 		ChangeOnly(true),
 		Required(true),
 		SourceField("src"),
+		EmptyValues("", 0),
 	})
 
 	assert.Equal(t, "message", opts.message)
@@ -25,4 +26,5 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, true, opts.changeOnly)
 	assert.Equal(t, true, opts.required)
 	assert.Equal(t, "src", opts.sourceField)
+	assert.Equal(t, []interface{}{"", 0}, opts.emptyValues)
 }

--- a/query.go
+++ b/query.go
@@ -468,6 +468,10 @@ func (query Query) Preload(record interface{}, field string) error {
 		for _, addr := range addrs[id] {
 			if addr.Kind() == reflect.Slice {
 				addr.Set(reflect.Append(addr, curr))
+			} else if addr.Kind() == reflect.Ptr {
+				currP := reflect.New(curr.Type())
+				currP.Elem().Set(curr)
+				addr.Set(currP)
 			} else {
 				addr.Set(curr)
 			}
@@ -580,15 +584,6 @@ func collectPreloadTarget(preload []preloadTarget, refIndex []int) (map[interfac
 		}
 
 		id := getPreloadID(refv)
-
-		// Create if ptr
-		if fv.Kind() == reflect.Ptr {
-			typ := fv.Type().Elem()
-			fv.Set(reflect.New(typ))
-
-			fv = fv.Elem()
-			preload[i].field = fv
-		}
 
 		// reset to zero if slice.
 		if fv.Kind() == reflect.Slice || fv.Kind() == reflect.Array {

--- a/query_test.go
+++ b/query_test.go
@@ -1314,7 +1314,8 @@ func TestQuery_Preload_belongsTo(t *testing.T) {
 }
 
 func TestQuery_Preload_ptr(t *testing.T) {
-	repo := Repo{}
+	mock := new(TestAdapter)
+	repo := Repo{adapter: mock}
 	query := repo.From("owners")
 
 	owner := Owner{}
@@ -1322,6 +1323,15 @@ func TestQuery_Preload_ptr(t *testing.T) {
 	assert.Nil(t, query.Preload(&owner, "User"))
 	assert.Nil(t, owner.User)
 	assert.Nil(t, owner.UserID)
+
+	id := 1
+	owner = Owner{UserID: &id}
+	result := []User{{ID: id}}
+	mock.Result(result).On("All", query.Where(In("id", id)), &[]User{}).Return(1, nil)
+
+	assert.Nil(t, query.Preload(&owner, "User"))
+	assert.Equal(t, result[0], *owner.User)
+	assert.Equal(t, &id, owner.UserID)
 }
 
 func TestQuery_Preload_slicePtr(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -1332,6 +1332,8 @@ func TestQuery_Preload_ptr(t *testing.T) {
 	assert.Nil(t, query.Preload(&owner, "User"))
 	assert.Equal(t, result[0], *owner.User)
 	assert.Equal(t, &id, owner.UserID)
+
+	mock.AssertExpectations(t)
 }
 
 func TestQuery_Preload_slicePtr(t *testing.T) {


### PR DESCRIPTION
### Before
If `preloadTarget[i].field.Kind()` is pointer, `collectPreloadTarget()` will change it to non pointer type. This will make the nil-pointer-field in `record interface{}`(the preload target type) have empty struct value.
### After
`collectPreloadTarget()` will not change the type, even `preloadTarget[i].field.Kind()` is pointer.