### PR TITLE
Preload target type not changed if it is pointer

### DIFF
--- a/query.go
+++ b/query.go
@@ -468,6 +468,10 @@ func (query Query) Preload(record interface{}, field string) error {
 		for _, addr := range addrs[id] {
 			if addr.Kind() == reflect.Slice {
 				addr.Set(reflect.Append(addr, curr))
+			} else if addr.Kind() == reflect.Ptr {
+				currP := reflect.New(curr.Type())
+				currP.Elem().Set(curr)
+				addr.Set(currP)
 			} else {
 				addr.Set(curr)
 			}
@@ -580,15 +584,6 @@ func collectPreloadTarget(preload []preloadTarget, refIndex []int) (map[interfac
 		}
 
 		id := getPreloadID(refv)
-
-		// Create if ptr
-		if fv.Kind() == reflect.Ptr {
-			typ := fv.Type().Elem()
-			fv.Set(reflect.New(typ))
-
-			fv = fv.Elem()
-			preload[i].field = fv
-		}
 
 		// reset to zero if slice.
 		if fv.Kind() == reflect.Slice || fv.Kind() == reflect.Array {

--- a/query_test.go
+++ b/query_test.go
@@ -1314,7 +1314,8 @@ func TestQuery_Preload_belongsTo(t *testing.T) {
 }
 
 func TestQuery_Preload_ptr(t *testing.T) {
-	repo := Repo{}
+	mock := new(TestAdapter)
+	repo := Repo{adapter: mock}
 	query := repo.From("owners")
 
 	owner := Owner{}
@@ -1322,6 +1323,15 @@ func TestQuery_Preload_ptr(t *testing.T) {
 	assert.Nil(t, query.Preload(&owner, "User"))
 	assert.Nil(t, owner.User)
 	assert.Nil(t, owner.UserID)
+
+	id := 1
+	owner = Owner{UserID: &id}
+	result := []User{{ID: id}}
+	mock.Result(result).On("All", query.Where(In("id", id)), &[]User{}).Return(1, nil)
+
+	assert.Nil(t, query.Preload(&owner, "User"))
+	assert.Equal(t, result[0], *owner.User)
+	assert.Equal(t, &id, owner.UserID)
 }
 
 func TestQuery_Preload_slicePtr(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -1332,6 +1332,8 @@ func TestQuery_Preload_ptr(t *testing.T) {
 	assert.Nil(t, query.Preload(&owner, "User"))
 	assert.Equal(t, result[0], *owner.User)
 	assert.Equal(t, &id, owner.UserID)
+
+	mock.AssertExpectations(t)
 }
 
 func TestQuery_Preload_slicePtr(t *testing.T) {


### PR DESCRIPTION
### Before
If `preloadTarget[i].field.Kind()` is pointer, `collectPreloadTarget()` will change it to non pointer type. This will make the nil-pointer-field in `record interface{}`(the preload target type) have empty struct value.
### After
`collectPreloadTarget()` will not change the type, even `preloadTarget[i].field.Kind()` is pointer.