### PR TITLE
Allow disable field escaping

### DIFF
--- a/adapter/sql/builder_test.go
+++ b/adapter/sql/builder_test.go
@@ -36,6 +36,11 @@ func TestBuilder_Find(t *testing.T) {
 			users.Select("id", "name"),
 		},
 		{
+			"SELECT `id`,FIELD(`gender`, \"male\") AS `order` FROM `users` ORDER BY `order` ASC;",
+			nil,
+			users.Select("id", "^FIELD(`gender`, \"male\") AS `order`").Order(Asc("order")),
+		},
+		{
 			"SELECT * FROM `users` JOIN `transactions` ON `transactions`.`id`=`users`.`transaction_id`;",
 			nil,
 			users.Join("transactions", Eq(I("transactions.id"), I("users.transaction_id"))),

--- a/adapter/sql/bulder.go
+++ b/adapter/sql/bulder.go
@@ -10,6 +10,9 @@ import (
 	"github.com/Fs02/grimoire/c"
 )
 
+// UnescapeCharacter disable field escaping when it starts with this character.
+var UnescapeCharacter byte = '^'
+
 var fieldCache sync.Map
 
 // Builder defines information of query builder.
@@ -513,10 +516,9 @@ func (builder *Builder) escape(field string) string {
 		return escapedField.(string)
 	}
 
-	start := strings.IndexRune(field, '(')
-	end := strings.IndexRune(field, ')')
-
-	if start >= 0 && end >= 0 && end > start {
+	if len(field) > 0 && field[0] == UnescapeCharacter {
+		escapedField = field[1:]
+	} else if start, end := strings.IndexRune(field, '('), strings.IndexRune(field, ')'); start >= 0 && end >= 0 && end > start {
 		escapedField = field[:start+1] + builder.escape(field[start+1:end]) + field[end:]
 	} else if strings.HasSuffix(field, "*") {
 		escapedField = builder.config.EscapeChar + strings.Replace(field, ".", builder.config.EscapeChar+".", 1)


### PR DESCRIPTION
Disable field escape when field is starts with `^`.
example:

```golang
Users.Select("^SUM(*) as `sum`")
// Equal to: SELECT SUM(*) as `sum` from USERS; 
```