### PR TITLE
Update PutDefault

### DIFF
--- a/changeset/put_default.go
+++ b/changeset/put_default.go
@@ -18,10 +18,9 @@ func PutDefault(ch *Changeset, field string, value interface{}, opts ...Option) 
 	if typ, exist := ch.types[field]; exist {
 		valTyp := reflect.TypeOf(value)
 		if valTyp.ConvertibleTo(typ) {
-			hasChange := ch.changes[field] != nil
-			hasValue := ch.values[field] != nil
-			valueZero := isZero(reflect.ValueOf(ch.values[field]))
-			if !hasChange && (!hasValue || valueZero) {
+			if ch.changes[field] == nil && // no changes
+				(ch.values[field] == nil || // no existing value
+					isZero(ch.values[field])) { // existing value is zero value
 				ch.changes[field] = value
 			}
 			return

--- a/changeset/put_default.go
+++ b/changeset/put_default.go
@@ -18,7 +18,10 @@ func PutDefault(ch *Changeset, field string, value interface{}, opts ...Option) 
 	if typ, exist := ch.types[field]; exist {
 		valTyp := reflect.TypeOf(value)
 		if valTyp.ConvertibleTo(typ) {
-			if ch.changes[field] == nil {
+			hasChange := ch.changes[field] != nil
+			hasValue := ch.values[field] != nil
+			valueZero := isZero(reflect.ValueOf(ch.values[field]))
+			if !hasChange && (!hasValue || valueZero) {
 				ch.changes[field] = value
 			}
 			return

--- a/changeset/put_default_test.go
+++ b/changeset/put_default_test.go
@@ -7,23 +7,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPutDefaultEmpty(t *testing.T) {
+func TestPutDefaultEmptyChanges(t *testing.T) {
 	ch := &Changeset{
 		changes: make(map[string]interface{}),
 		values: map[string]interface{}{
 			"field1": 0,
+			"field2": 5,
 		},
 		types: map[string]reflect.Type{
 			"field1": reflect.TypeOf(0),
+			"field2": reflect.TypeOf(5),
 		},
 	}
 
 	PutDefault(ch, "field1", 10)
+	PutDefault(ch, "field2", 10)
 
 	assert.Nil(t, ch.Error())
 	assert.Nil(t, ch.Errors())
 	assert.Equal(t, 1, len(ch.Changes()))
 	assert.Equal(t, 10, ch.Changes()["field1"])
+	assert.Nil(t, ch.Changes()["field2"])
 }
 
 func TestPutDefaultExisting(t *testing.T) {

--- a/changeset/put_default_test.go
+++ b/changeset/put_default_test.go
@@ -47,6 +47,42 @@ func TestPutDefaultExisting(t *testing.T) {
 	assert.Equal(t, "default_val", ch.Changes()["field2"])
 }
 
+func TestPutDefaultNoValueWithInput(t *testing.T) {
+	ch := &Changeset{
+		changes: map[string]interface{}{
+			"field2": "input_val",
+		},
+		values: map[string]interface{}{},
+		types: map[string]reflect.Type{
+			"field2": reflect.TypeOf(""),
+		},
+	}
+
+	PutDefault(ch, "field2", "must not be changed")
+
+	assert.Nil(t, ch.Error())
+	assert.Nil(t, ch.Errors())
+	assert.Equal(t, 1, len(ch.Changes()))
+	assert.Equal(t, "input_val", ch.Changes()["field2"])
+}
+
+func TestPutDefaultNoValueNoChange(t *testing.T) {
+	ch := &Changeset{
+		changes: map[string]interface{}{},
+		values:  map[string]interface{}{},
+		types: map[string]reflect.Type{
+			"field2": reflect.TypeOf(""),
+		},
+	}
+
+	PutDefault(ch, "field2", "must not be changed")
+
+	assert.Nil(t, ch.Error())
+	assert.Nil(t, ch.Errors())
+	assert.Equal(t, 1, len(ch.Changes()))
+	assert.Equal(t, "must not be changed", ch.Changes()["field2"])
+}
+
 func TestPutDefaultInvalid(t *testing.T) {
 	ch := &Changeset{
 		changes: make(map[string]interface{}),


### PR DESCRIPTION
Update `PutDefault` Method
Put default value only if there's no change and no existing value.

Problem:
- `changeset.Cast` will give empty changes when given input with same value as existing value, triggering the `PutDefault`