### PR TITLE
Fix ValidateRequired: Don't check empty value with isZero

### DIFF
--- a/changeset/validate_required.go
+++ b/changeset/validate_required.go
@@ -33,13 +33,13 @@ func ValidateRequired(ch *Changeset, fields []string, opts ...Option) {
 			continue
 		}
 
-		zero, isZeroer := val.(isZeroer)
-		if exist && isZeroer && !zero.IsZero() {
+		zeroer, isZeroer := val.(isZeroer)
+		if exist && isZeroer && !zeroer.IsZero() {
 			continue
 		}
 
-		// Only check zero value with isZero if val is not string since it has been checked before.
-		if exist && !isStr && !isZero(val) {
+		// Only check nil value if val is not string and isZeroer since it has been checked before.
+		if exist && !isStr && !isZeroer && val != nil {
 			continue
 		}
 

--- a/changeset/validate_required_test.go
+++ b/changeset/validate_required_test.go
@@ -2,12 +2,19 @@ package changeset
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Fs02/grimoire/params"
 	"github.com/stretchr/testify/assert"
 )
+
+type customString string
+
+func (c customString) IsZero() bool {
+	return strings.TrimSpace(string(c)) == ""
+}
 
 func TestValidateRequired(t *testing.T) {
 	ch := &Changeset{
@@ -75,7 +82,6 @@ func TestValidateRequired_error(t *testing.T) {
 }
 
 func TestValidateRequired_cast_error(t *testing.T) {
-	type customString string
 	type customType struct {
 		Field1    customString
 		Field2    customString


### PR DESCRIPTION
There's an issue in ValidateRequired when using changeset with default value.
See the example here: https://play.golang.org/p/IFXG3A6s9ey

Since it checks `changeset.changes` with `isZero`, `some_bool` field is considered empty because its value is `false`.

The solution is to revert zero value check with `isZero`. To compare with default value, implement `isZeroer` interface instead.





note: This changes has been tested in papyrus repository and all tests pass.







