### PR TITLE
Bypass Validation for Setting Changes with Empty Values

### DIFF
--- a/changeset/validate_min.go
+++ b/changeset/validate_min.go
@@ -11,15 +11,15 @@ var ValidateMinErrorMessage = "{field} must be more than {min}"
 // ValidateMin validates the value of given field is not smaller than min.
 // Validation can be performed against string, slice and numbers.
 func ValidateMin(ch *Changeset, field string, min int, opts ...Option) {
-	val, exist := ch.changes[field]
-	if !exist {
-		return
-	}
-
 	options := Options{
 		message: ValidateMinErrorMessage,
 	}
 	options.apply(opts)
+
+	val, exist := ch.changes[field]
+	if !exist || contains(options.emptyValues, val) {
+		return
+	}
 
 	invalid := false
 

--- a/changeset/validate_min_test.go
+++ b/changeset/validate_min_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidateMin_EmptyValue(t *testing.T) {
+	ch := &Changeset{
+		changes: map[string]interface{}{
+			"field": "",
+		},
+	}
+	ValidateMin(ch, "field", 5, EmptyValues(""))
+	assert.Nil(t, ch.Errors())
+
+	ValidateMin(ch, "field", 5)
+	assert.NotNil(t, ch.Errors())
+}
+
 func TestValidateMin(t *testing.T) {
 	tests := []interface{}{
 		"long text",

--- a/changeset/validate_pattern.go
+++ b/changeset/validate_pattern.go
@@ -10,15 +10,15 @@ var ValidatePatternErrorMessage = "{field}'s format is invalid"
 
 // ValidatePattern validates the value of given field to match given pattern.
 func ValidatePattern(ch *Changeset, field string, pattern string, opts ...Option) {
-	val, exist := ch.changes[field]
-	if !exist {
-		return
-	}
-
 	options := Options{
 		message: ValidatePatternErrorMessage,
 	}
 	options.apply(opts)
+
+	val, exist := ch.changes[field]
+	if !exist || contains(options.emptyValues, val) {
+		return
+	}
 
 	if str, ok := val.(string); ok {
 		match, _ := regexp.MatchString(pattern, str)

--- a/changeset/validate_pattern_test.go
+++ b/changeset/validate_pattern_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidatePattern_EmptyValue(t *testing.T) {
+	ch := &Changeset{
+		changes: map[string]interface{}{
+			"field": "",
+		},
+	}
+	ValidatePattern(ch, "field", "foo.*", EmptyValues(""))
+	assert.Nil(t, ch.Errors())
+
+	ValidatePattern(ch, "field", "foo.*")
+	assert.NotNil(t, ch.Errors())
+}
+
 func TestValidatePattern(t *testing.T) {
 	tests := []interface{}{
 		"seafood",

--- a/changeset/validate_range.go
+++ b/changeset/validate_range.go
@@ -11,15 +11,15 @@ var ValidateRangeErrorMessage = "{field} must be between {min} and {max}"
 // ValidateRange validates the value of given field is not larger than max and not smaller than min.
 // Validation can be performed against string, slice and numbers.
 func ValidateRange(ch *Changeset, field string, min int, max int, opts ...Option) {
-	val, exist := ch.changes[field]
-	if !exist {
-		return
-	}
-
 	options := Options{
 		message: ValidateRangeErrorMessage,
 	}
 	options.apply(opts)
+
+	val, exist := ch.changes[field]
+	if !exist || contains(options.emptyValues, val) {
+		return
+	}
 
 	invalid := false
 

--- a/changeset/validate_range_test.go
+++ b/changeset/validate_range_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidateRange_EmptyValue(t *testing.T) {
+	ch := &Changeset{
+		changes: map[string]interface{}{
+			"field": "",
+		},
+	}
+	ValidateRange(ch, "field", 5, 15, EmptyValues(""))
+	assert.Nil(t, ch.Errors())
+
+	ValidateRange(ch, "field", 5, 15)
+	assert.NotNil(t, ch.Errors())
+}
+
 func TestValidateRange(t *testing.T) {
 	tests := []interface{}{
 		"long text",

--- a/changeset/validate_regexp.go
+++ b/changeset/validate_regexp.go
@@ -10,15 +10,15 @@ var ValidateRegexpErrorMessage = "{field}'s format is invalid"
 
 // ValidateRegexp validates the value of given field to match given regexp.
 func ValidateRegexp(ch *Changeset, field string, exp *regexp.Regexp, opts ...Option) {
-	val, exist := ch.changes[field]
-	if !exist {
-		return
-	}
-
 	options := Options{
 		message: ValidateRegexpErrorMessage,
 	}
 	options.apply(opts)
+
+	val, exist := ch.changes[field]
+	if !exist || contains(options.emptyValues, val) {
+		return
+	}
 
 	if str, ok := val.(string); ok {
 		match := exp.MatchString(str)

--- a/changeset/validate_regexp_test.go
+++ b/changeset/validate_regexp_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidateRegexp_EmptyValue(t *testing.T) {
+	exp := regexp.MustCompile(`foo.*`)
+
+	ch := &Changeset{
+		changes: map[string]interface{}{
+			"field": "",
+		},
+	}
+	ValidateRegexp(ch, "field", exp, EmptyValues(""))
+	assert.Nil(t, ch.Errors())
+
+	ValidateRegexp(ch, "field", exp)
+	assert.NotNil(t, ch.Errors())
+}
+
 func TestValidateRegexp(t *testing.T) {
 	exp := regexp.MustCompile(`foo.*`)
 


### PR DESCRIPTION
Issue: The validation is still running when setting a field with empty values using `changeset.EmptyValues(..)` options, giving a validation error. 

This is an issue when a field is intentionally set to an empty value.